### PR TITLE
front-page.php miraculously goes to Startseite

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head><scipt src="obj_fui.js"></script></head>
+<body>
+<p id="demo"></p>
+<script>
+var user = {
+    name: "tom",
+    say: function (words) { alert(words); }
+};
+
+document.getElementById("demo").innerHTML = user.say("honk");
+</script>
+
+
+</body>
+</html>


### PR DESCRIPTION
I created Startseite via the WP Admin Page Menü and
set it to static start page
The front-page.php I created by hand and uploaded via ftp to the theme two sixteen
Miraculously (by the fall back structure of Wordpress) the front-page.php was shown as starting page of the Website although another page "Startseite" with completely or no content was set as static home page.
Wordpress recognized my self-created front-page.php as starting page JUST BECAUSE OF ITS NAME (the naming conventions of Wordpress and its built in Template-Hierarchy)
